### PR TITLE
Fix markdown presentation issues on NPM page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # unzalgo
 Transforms ť͈̓̆h̏̔̐̑ì̭ͯ͞s̈́̄̑͋ into *this* without breaking internationalization.
+
 ## Installation
 ```bash
 $ npm install -D unzalgo
@@ -22,12 +23,15 @@ and, at the same time, keep all diacritics in
 Z nich ovšem pouze předposlední sdílí s výše uvedenou větou příliš žluťoučký kůň úpěl […]
 ```
 which remains unchanged after a transformation.
+
 ## Is there a demo?
 Yes! You can check it out [here](https://kdex.github.io/unzalgo/). You can edit the text at the top; the lower part shows the text after `Unzalgo.prototype.clean` using the default threshold.
+
 ## How does it work?
 By the laws of Unicode, every Unicode character is assigned to one [character category](http://www.unicode.org/reports/tr49/Categories.txt). Zalgo text uses characters that belong to the `Mn` and `Me` category.
 
 First, the text is divided into words; each word is then assigned to a score that corresponds to the usage of the categories above, combined with small use of statistics. If the score exceeds a threshold, we're able to detect Zalgo text (which allows us to strip away all characters from the above categories).
+
 ## Getting started
 ```js
 import { clean, isZalgo }  from "unzalgo";
@@ -51,6 +55,7 @@ Determines if the string `string` consists of Zalgo text using the threshold `th
 A threshold of `0` indicates that the string should be classified as Zalgo text if it contains at least **one** `Mn` or `Me` category Unicode codepoints. A threshold of `1` indicates that **all** codepoints in `string` must either be categorized as `Mn` or `Me`. The threshold defaults to `0.5`.
 
 Returns `true` if `string` is a Zalgo text, else `false`.
+
 #### Unzalgo.prototype.clean(string, threshold)
 Removes all Zalgo text characters for every word in `string` if the word is Zalgo text. The number `threshold` falls between `0` and `1`.
 


### PR DESCRIPTION
It seems like npmjs.com doesn't like the fact that there are no enters before a heading (expect in the case of a code block), this commit adds empty lines before commit headings in hopes of fixing this bug