### PR TITLE
added browsers target to .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,8 @@
 	presets: [
 		["@babel/preset-env", {
 			"targets": {
-				"node": "current"
+				"node": "current",
+				"browsers": "last 2 versions"
 			}
 		}],
 		"babel-preset-minify"


### PR DESCRIPTION
unzalgo is transpiled to rather modern version of JS. It has features not supported in some browsers, that are targeted in my project, such as Android 5 and iOs 9 native browsers
I think that can be fixed easily with adding new target to `.babelrc`
I suppose that might be useful for other people too