### PR TITLE
return string without modifications when no zalgos are transformed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,10 @@ export const isZalgo = (string, threshold = DEFAULT_THRESHOLD) => {
 */
 export const clean = (string, threshold = DEFAULT_THRESHOLD) => {
 	let cleaned = "";
+	let hadZalgos = false;
 	for (const word of decompose(string).split(/(\s+)/)) {
 		if (isZalgo(word, threshold)) {
+			hadZalgos = true;
 			for (const character of word) {
 				if (!categories.test(character)) {
 					cleaned += character;
@@ -70,6 +72,7 @@ export const clean = (string, threshold = DEFAULT_THRESHOLD) => {
 			cleaned += word;
 		}
 	}
-	return compose(cleaned);
+	if (hadZalgos) return compose(cleaned);
+	return string
 };
 export default clean;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,7 +48,7 @@ test("some diacritics", () => {
 		1 / 6,
 		2 / 9
 	]);
-	expectClean(text, compose(text));
+	expectClean(text, text);
 	expectNoZalgo(text);
 	expectClean(text, "having this text display normally, since some languages actually use these symbols", 0);
 });


### PR DESCRIPTION
Hi,

Is there a reason the cleaned string is normalized (NFC) even when no zalgos were found on it?

Thanks~